### PR TITLE
Change rabin sign flow

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -1,22 +1,24 @@
 # A simple python script for Rabin Signature
 
-1. Generate key pairs with a seed. **Replace** `nrabin` in `rabin.py` with the `nrabin` in the output.
+1. Generate key pairs with a seed.
+
 ```bash
-> python rabin.py G 01
- generate primes ... 
-nrabin =  0x15525796ddab817a3c54c4bea4ef564f090c5909b36818c1c13b9e674cf524aa3387a408f9b63c0d88d11a76471f9f2c3f29c47a637aa60bf5e120d1f5a65221
+> python3 rabin.py G 01
+generate primes ... 
+n_rabin = 0x15525796ddab817a3c54c4bea4ef564f090c5909b36818c1c13b9e674cf524aa3387a408f9b63c0d88d11a76471f9f2c3f29c47a637aa60bf5e120d1f5a65221
 ```
 
 2. Sign a message: get number of padding bytes and signature
+
 ```bash
-> python rabin.py S 00112233445566778899aabbccddeeff
-paddingnum: 4
- digital signature:
- 0x12f1dd2e0965dc433b0d32b86333b0fb432df592f6108803d7afe51a14a0e867045fe22af85862b8e744700920e0b7e430a192440a714277efb895b51120e4cc
+> python3 rabin.py S 00112233445566778899aabbccddeeff
+padding = 4
+digital signature = 0x12f1dd2e0965dc433b0d32b86333b0fb432df592f6108803d7afe51a14a0e867045fe22af85862b8e744700920e0b7e430a192440a714277efb895b51120e4cc
 ```
 
 3. Verify signature with results from step 2
+
 ```bash
-> python rabin.py V 00112233445566778899aabbccddeeff 4 12f1dd2e0965dc433b0d32b86333b0fb432df592f6108803d7afe51a14a0e867045fe22af85862b8e744700920e0b7e430a192440a714277efb895b51120e4cc
+> python3 rabin.py V 00112233445566778899aabbccddeeff 4 12f1dd2e0965dc433b0d32b86333b0fb432df592f6108803d7afe51a14a0e867045fe22af85862b8e744700920e0b7e430a192440a714277efb895b51120e4cc
 result of verification: True
 ```

--- a/py/rabin.py
+++ b/py/rabin.py
@@ -1,102 +1,116 @@
-import hashlib, sys
-
-nrabin = 0x15525796ddab817a3c54c4bea4ef564f090c5909b36818c1c13b9e674cf524aa3387a408f9b63c0d88d11a76471f9f2c3f29c47a637aa60bf5e120d1f5a65221
-
-def gcd(a,b):
-  if b > a:
-    a,b = b,a
-  while b > 0:
-    a,b = b,a % b
-  return a
-
-def nextPrime(p):
- while p % 4 != 3:
-   p = p + 1
- return nextPrime_3(p)
-  
-def nextPrime_3(p):
-  m_ = 3*5*7*11*13*17*19*23*29
-  while gcd(p,m_) != 1:
-    p = p + 4 
-  if (pow(2,p-1,p) != 1):
-      return nextPrime_3(p + 4)
-  if (pow(3,p-1,p) != 1):
-      return nextPrime_3(p + 4)
-  if (pow(5,p-1,p) != 1):
-      return nextPrime_3(p + 4)
-  if (pow(17,p-1,p) != 1):
-      return nextPrime_3(p + 4)
-  return p
-
-# x: bytes
-# return: int
-def h(x):
-  hx = hashlib.sha256(x).digest()
-  idx = len(hx)//2
-  hl = hashlib.sha256(hx[:idx]).digest()
-  hr = hashlib.sha256(hx[idx:]).digest()
-  return int.from_bytes(hl + hr, 'little')
-
-# m: bytes
-def root(m, p, q):
-  i = 0
-  while True:
-    x = h(m) % nrabin
-    sig =   pow(p,q-2,q) * p * pow(x,(q+1)//4,q) 
-    sig = ( pow(q,p-2,p) * q * pow(x,(p+1)//4,p) + sig ) % (nrabin) 
-    if (sig * sig) % nrabin == x:
-      break
-    m = m + bytes.fromhex("00")
-    i = i + 1
-  print("paddingnum: " + str(i))
-  return sig
-
-def writeNumber(number, fnam):
-  with open(fnam + '.txt', 'w') as f:
-    f.write('%d' % number)
-
-def readNumber(fnam):
-  with open(fnam + '.txt', 'r') as f:
-    return int(f.read())
-
-def hF(m, paddingnum):
-  return h(m + bytes.fromhex("00") * paddingnum) % nrabin
-
-def sF(hexmsg):
-  p = readNumber("p")
-  q = readNumber("q")
-  return root(bytes.fromhex(hexmsg), p, q)
+import hashlib
+import sys
 
 
-def vF(hexmsg, paddingnum, s):
-  return hF(bytes.fromhex(hexmsg), paddingnum) == (s * s) % nrabin
- 
-print("\n\n rabin signature - sCrypt Inc 2020 adapted from Scheerer - all rights reserved\n\n")
-print("\n\n rabin signature - copyright Scheerer Software 2018 - all rights reserved\n\n")
-print("First parameter is V (Verify) or S (Sign) or G (Generate)\n\n")
-print("\n\n verify signature (2 parameters):")
-print("   > python rabin.py V <hexmessage> <paddingnum> <digital signature> ")
+def gcd(a, b):
+    if b > a:
+        a, b = b, a
+    while b > 0:
+        a, b = b, a % b
+    return a
 
-print(" create signature S (2 parameter):")
-print("   > python rabin.py S <hexmessage> \n\n")
 
-print(" generate key pair G (2 parameter):")
-print("   > python rabin.py G <hexseed> \n\n")
+def next_prime(p):
+    while p % 4 != 3:
+        p = p + 1
+    return next_prime_3(p)
 
-print(" number of parameters is " + str(len(sys.argv)-1))
-print(" ")
-print(" ")
 
-if len(sys.argv) == 5 and sys.argv[1] == "V":
-  print("result of verification: " + str(vF(sys.argv[2], int(sys.argv[3]), int(sys.argv[4], 16))))
+def next_prime_3(p):
+    m_ = 3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 29
+    while gcd(p, m_) != 1:
+        p = p + 4
+    if pow(2, p - 1, p) != 1 or pow(3, p - 1, p) != 1 or pow(5, p - 1, p) != 1 or pow(17, p - 1, p) != 1:
+        return next_prime_3(p + 4)
+    return p
 
-if len(sys.argv) == 3 and sys.argv[1] == "S":
-  print((" digital signature:\n " + hex(sF(sys.argv[2]))))
-     
-if len(sys.argv) == 3 and sys.argv[1] == "G":
-  print(" generate primes ... ")
-  p = nextPrime( h(bytes.fromhex(sys.argv[2])) % (2**501 + 1) )  
-  q = nextPrime( h(bytes.fromhex(sys.argv[2] + '00')) % (2**501 + 1) )  
-  writeNumber(p, 'p')                     
-  writeNumber(q, 'q')     
-  print("nrabin = ", hex(p * q))
+
+def hash_to_int(x: bytes) -> int:
+    hx = hashlib.sha256(x).digest()
+    # Expand to 3072 bits
+    for i in range(11):
+        hx += hashlib.sha256(hx).digest()
+    return int.from_bytes(hx, 'little')
+
+
+def sign_rabin(p: int, q: int, digest: bytes) -> tuple:
+    """
+    :param p: part of private key
+    :param q: part of private key
+    :param digest: message digest to sign
+    :return: rabin signature (S: int, padding: int)
+    """
+    n = p * q
+    i = 0
+    while True:
+        h = hash_to_int(digest + b'\x00' * i) % n
+        if (h % p == 0 or pow(h, (p - 1) // 2, p) == 1) and (h % q == 0 or pow(h, (q - 1) // 2, q) == 1):
+            break
+        i += 1
+    lp = q * pow(h, (p + 1) // 4, p) * pow(q, p - 2, p)
+    rp = p * pow(h, (q + 1) // 4, q) * pow(p, q - 2, q)
+    s = (lp + rp) % n
+    return s, i
+
+
+def verify_rabin(n: int, digest: bytes, s: int, padding: int) -> bool:
+    """
+    :param n: rabin public key
+    :param digest: digest of signed message
+    :param s: S of signature
+    :param padding: the number of padding bytes
+    """
+    return hash_to_int(digest + b'\x00' * padding) % n == (s * s) % n
+
+
+def write_number(number, filename):
+    with open(f'{filename}.txt', 'w') as f:
+        f.write('%d' % number)
+
+
+def read_number(filename):
+    with open(f'{filename}.txt', 'r') as f:
+        return int(f.read())
+
+
+def sign(hex_message: str):
+    p = read_number('p')
+    q = read_number('q')
+    return sign_rabin(p, q, bytes.fromhex(hex_message))
+
+
+def verify(hex_message, padding, hex_signature):
+    n = read_number('n')
+    return verify_rabin(n, bytes.fromhex(hex_message), hex_signature, padding)
+
+
+if __name__ == '__main__':
+    print('\n rabin signature - sCrypt Inc 2020 adapted from Scheerer - all rights reserved')
+    print('\n rabin signature - copyright Scheerer Software 2018 - all rights reserved')
+
+    print('\n\nFirst parameter is V (Verify) or S (Sign) or G (Generate)')
+    print('\n verify signature (2 parameters):')
+    print('   > python rabin.py V <hex message> <padding> <digital signature>')
+    print('\n create signature S (2 parameter):')
+    print('   > python rabin.py S <hex message>')
+    print('\n generate key pair G (2 parameter):')
+    print('   > python rabin.py G <hex seed>')
+
+    print(f'\n\nnumber of parameters is {len(sys.argv) - 1}')
+
+    if len(sys.argv) == 5 and sys.argv[1] == 'V':
+        print(f'\n result of verification: {verify(sys.argv[2], int(sys.argv[3]), int(sys.argv[4], 16))}')
+
+    if len(sys.argv) == 3 and sys.argv[1] == 'S':
+        sig, pad = sign(sys.argv[2])
+        print(f'\n padding = {pad}')
+        print(f' digital signature = {hex(sig)}')
+
+    if len(sys.argv) == 3 and sys.argv[1] == 'G':
+        print('\n generate primes ... ')
+        p_rabin = next_prime(hash_to_int(bytes.fromhex(sys.argv[2])) % (2 ** 501 + 1))
+        q_rabin = next_prime(hash_to_int(bytes.fromhex(sys.argv[2] + '00')) % (2 ** 501 + 1))
+        write_number(p_rabin, 'p')
+        write_number(q_rabin, 'q')
+        write_number(p_rabin * q_rabin, 'n')
+        print(f'\n n_rabin = {hex(p_rabin * q_rabin)}')


### PR DESCRIPTION
When signing Rabin, the original code is following the equation to calculate S first, then checks if `(S * S) % n == H % n`. 
If no, change to another H (padding m with 0x00) then re-calculate S, until passing the validation.

Which can be changed to:
1. find a valid H first, that H is the quadratic residue of module n.
2. follow the equation to calculate S, then return (S, U)

See also: [Rabin 数字签名](https://aaron67.cc/2021/07/10/rabin-signatures/)